### PR TITLE
Make -l mode faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ Here's the code
 #!/usr/bin/env ruby
 
 def execute(_, code)
-  puts _.instance_eval(code)
+  puts _.instance_eval(&code)
 rescue Errno::EPIPE
   exit
 end
 
 single_line = ARGV[0] == '-l'
-lines = $stdin.readlines
 code = ARGV.drop(single_line ? 1 : 0).join(' ')
-single_line ? lines.each { |l| execute(l, code) } : execute(lines, code)
+code = eval("Proc.new { #{code} }")
+single_line ? STDIN.each { |l| execute(l, code) } : execute(STDIN.readlines, code)
 ```
 
 Clone this repo and copy the `rb` file to somewhere in your path (or just copy and paste the above).

--- a/rb
+++ b/rb
@@ -1,12 +1,12 @@
 #!/usr/bin/env ruby
 
 def execute(_, code)
-  puts _.instance_eval(code)
+  puts _.instance_eval(&code)
 rescue Errno::EPIPE
   exit
 end
 
 single_line = ARGV[0] == '-l'
-lines = $stdin.readlines
 code = ARGV.drop(single_line ? 1 : 0).join(' ')
-single_line ? lines.each { |l| execute(l, code) } : execute(lines, code)
+code = eval("Proc.new { #{code} }")
+single_line ? STDIN.each { |l| execute(l, code) } : execute(STDIN.readlines, code)


### PR DESCRIPTION
Previously `-l` unnecessarily loaded the whole file into memory and also re-compiled the Ruby for every line. This PR makes it faster and with less memory use, while maintaining the fact that the script is 10 lines of code!

```
# before
$ cat /usr/share/dict/words | time rb -l 'gsub("h","o")' | wc -l
        2.84 real         2.76 user         0.06 sys
  235886

# after switching to not loading all lines ahead of time
$ cat /usr/share/dict/words | time rb -l 'gsub("h","o")' | wc -l
        2.23 real         2.21 user         0.02 sys
  235886

# Only eval Ruby once at start
        0.51 real         0.49 user         0.01 sys
  235886
```

@thisredone 