### PR TITLE
9 instead of 10 lines of code - FTW!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rb
 
-With 10 lines of Ruby replace most of the command line tools that you use to process text inside of the terminal.
+With 9 lines of Ruby replace most of the command line tools that you use to process text inside of the terminal.
 
 
 
@@ -15,9 +15,8 @@ rescue Errno::EPIPE
   exit
 end
 
-single_line = ARGV[0] == '-l'
-expr = ARGV.drop(single_line ? 1 : 0).join(' ')
-code = eval("Proc.new { #{expr} }")
+single_line = ARGV.delete('-l')
+code = eval("Proc.new { #{ARGV.join(' ')} }")
 single_line ? STDIN.each { |l| execute(l.chomp, code) } : execute(STDIN.each_line, code)
 ```
 

--- a/rb
+++ b/rb
@@ -6,7 +6,6 @@ rescue Errno::EPIPE
   exit
 end
 
-single_line = ARGV[0] == '-l'
-expr = ARGV.drop(single_line ? 1 : 0).join(' ')
-code = eval("Proc.new { #{expr} }")
+single_line = ARGV.delete('-l')
+code = eval("Proc.new { #{ARGV.join(' ')} }")
 single_line ? STDIN.each { |l| execute(l.chomp, code) } : execute(STDIN.each_line, code)


### PR DESCRIPTION
@thisredone - this is a slightly tentative change request, as I appreciate that the behaviour is slightly different _(so feel free to close it without merging)_ but OML... 9 lines of code instead of 10!!!  :smile:

The issue with this approach is that if `-l` somehow appears in the subsequent clargs _(the ones that make up the Ruby expression)_ then they will be deleted as well.... but on the other hand: I cannot imagine a valid or meaningful Ruby expression where a "naked" `-l` would make any sense, so it might be fair and safe to assume there'll never be one.