### PR TITLE
Add filter support, when the block returns nil

### DIFF
--- a/rb
+++ b/rb
@@ -2,7 +2,8 @@
 File.join(Dir.home, '.rbrc').tap { |f| load f if File.exists?(f) }
 
 def execute(_, code)
-  puts _.instance_eval(&code)
+  result = _.instance_eval(&code)
+  puts result unless result.nil?
 rescue Errno::EPIPE
   exit
 end


### PR DESCRIPTION
The change enables filter of the origin lines by return nil from the block.
For example, return only lines begins with "A":
`cat testfile | rb -l  "start_with?('A') ? self : nil"`
