### PR TITLE
Fix undefined method exists? in Ruby >=3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Here's the code
 
 ```ruby
 #!/usr/bin/env ruby
-File.join(Dir.home, '.rbrc').tap { |f| load f if File.exists?(f) }
+File.join(Dir.home, '.rbrc').tap { |f| load f if File.exist?(f) }
 
 def execute(_, code)
   puts _.instance_eval(&code)

--- a/rb
+++ b/rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-File.join(Dir.home, '.rbrc').tap { |f| load f if File.exists?(f) }
+File.join(Dir.home, '.rbrc').tap { |f| load f if File.exist?(f) }
 
 def execute(_, code)
   puts _.instance_eval(&code)


### PR DESCRIPTION
`File.exists?` was removed in Ruby 3.2.

See https://rubyreferences.github.io/rubychanges/3.2.html#:~:text=File.exists%3F,a%20method%20name.
